### PR TITLE
docs: Arrumando os links quebrados

### DIFF
--- a/docs/lista-1.md
+++ b/docs/lista-1.md
@@ -5,9 +5,9 @@ Abaixo estão listados os exercícios e os arquivos a eles associados:
 
 | Exercício | Programa em C |
 | :- | :- | 
-| Exercício 1 | [`src/lista-1/convert_to_int.c`](src/lista-1/convert_to_int.c) |
-| Exercício 2 | [`src/lista-1/int_to_any_base.c`](src/lista-1/int_to_any_base.c) |
-| Exercício 3 | [`src/lista-1/float_to_any_base.c`](src/lista-1/float_to_any_base.c) |
+| Exercício 1 | [`src/lista-1/convert_to_int.c`](/src/lista-1/convert_to_int.c) |
+| Exercício 2 | [`src/lista-1/int_to_any_base.c`](/src/lista-1/int_to_any_base.c) |
+| Exercício 3 | [`src/lista-1/float_to_any_base.c`](/src/lista-1/float_to_any_base.c) |
 
 > [!NOTE]
 > Os arquivos foram nomeados de modo arbitrário.


### PR DESCRIPTION
Os links para os arquivos .c da lista 1 estavam quebrados. Eles foram corrigidos para apontar para os arquivos corretos.